### PR TITLE
fix: remove become option at homebrew tasks

### DIFF
--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -2,5 +2,4 @@
   homebrew:
     name: "{{ item }}"
   items: "{{ pyenv_darwin_build_dependencies }}"
-  become: "{{ pyenv_nonroot }}"
   when: pyenv_is_dependencies_installed

--- a/tests/roles/git/tasks/Darwin.yml
+++ b/tests/roles/git/tasks/Darwin.yml
@@ -1,4 +1,3 @@
 - name: Install git
   homebrew:
     name: git
-  become: "{{ pyenv_nonroot }}"


### PR DESCRIPTION
```
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
```