### PR TITLE
also use 'pyenv init --path' command to set environment

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,11 @@
         dest: "{{ pyenv_rc_path }}"
         line: 'eval "$(pyenv init -)"'
         create: true
+    - name: Add configurations to ~/.bashrc, ~/.profile, or ~/.zshrc or etc
+      lineinfile:
+        dest: "{{ pyenv_rc_path }}"
+        line: 'eval "$(pyenv init --path)"'
+        create: true
   when: pyenv_rc_path != "NOT ADD"
 - include_tasks: "{{ pyenv_os_families.get(ansible_os_family, 'default') }}.yml"
   when: pyenv_is_dependencies_installed and ansible_os_family in pyenv_os_families


### PR DESCRIPTION
Add missing  'pyenv init --path'  to profile file so that environment is set correctly for pyenv commands to work.